### PR TITLE
Add a willSendRequest method

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "apollo-datasource": "^0.2.2",
     "apollo-server-caching": "^0.2.2",
-    "apollo-server-errors": "^2.2.0"
+    "apollo-server-errors": "^2.2.0",
+    "apollo-server-types": "^0.2.1"
   }
 }


### PR DESCRIPTION
We are using WS-Trust and STS for creating SAML2 tokens for authentication on our SOAP services.

That means we need a way to create tokens (or fetched cached) per request.

I looked first at implementing this as a custom security policy on `node-soap`, but it only offers support for synchronous security methods. Adding support for asynchronous got very complex.

This `willSendRequest` method mimics the same from RESTDataSource and allow modification (adding SOAP headers) of the client for every request.