### PR TITLE
Keep the context on the instance

### DIFF
--- a/src/SOAPDataSource.ts
+++ b/src/SOAPDataSource.ts
@@ -7,6 +7,7 @@ export type ClientCreator = () => Promise<Client>;
 
 export abstract class SOAPDataSource<TContext = any> extends DataSource {
   cache!: SOAPCache;
+  context!: TContext;
   private clientCreator: ClientCreator;
   private client: Client;
 
@@ -27,6 +28,7 @@ export abstract class SOAPDataSource<TContext = any> extends DataSource {
   }
 
   initialize(config: DataSourceConfig<TContext>): void {
+    this.context = config.context;
     this.cache = new SOAPCache(config.cache);
   }
 

--- a/test/SOAPDataSource.spec.ts
+++ b/test/SOAPDataSource.spec.ts
@@ -18,12 +18,14 @@ const client = {
 
 let dataSource: TestSOAPDataSource;
 
-describe('S3Cache', () => {
+describe('SOAPDataSource', () => {
+  const context = {};
+
   beforeEach(() => {
     dataSource = new TestSOAPDataSource(() => client as any);
     dataSource.initialize({
       cache: new InMemoryLRUCache(),
-      context: {},
+      context
     });
   });
 
@@ -64,5 +66,9 @@ describe('S3Cache', () => {
     );
 
     expect(client.sayHello).toHaveBeenCalledTimes(1);
+  });
+
+  it('Keeps the DataSource Context', async () => {
+    expect(Object.is(dataSource.context, context)).toBe(true);
   });
 });


### PR DESCRIPTION
It is useful for methods to have the Context passed in when initializing
the DataSource.

Add it as an instance variable and keep it.