### PR TITLE
Do not pass SOAP error to ApolloError

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "soap": "*"
   },
   "dependencies": {
-    "@ovotech/typesafe-get": "^2.0.1",
     "apollo-datasource": "^0.2.2",
     "apollo-server-caching": "^0.2.2",
     "apollo-server-errors": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@ovotech/apollo-datasource-soap",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "SOAPDataSource is responsible for fetching data using soap",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "source": "src/index.ts",
   "types": "dist/types/index.d.ts",
-  "repository": "git@github.com:ovotech/apollo-datasource-s3.git",
+  "repository": "git@github.com:ovotech/apollo-datasource-soap.git",
   "author": "Ivan Kerin <ikerin@gmail.com>",
   "license": "Apache-2.0",
   "scripts": {
@@ -14,8 +14,17 @@
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "build-cjs": "tsc --outDir dist/cjs/",
     "build-es": "tsc --outDir dist/es/ --module esnext --declaration --declarationDir dist/types/",
-    "build": "yarn build-cjs && yarn build-es",
-    "soap": "^0.25.0"
+    "build": "yarn build-cjs && yarn build-es"
+  },
+  "peerDependencies": {
+    "soap": "*"
+  },
+  "dependencies": {
+    "@ovotech/typesafe-get": "^2.0.1",
+    "apollo-datasource": "^0.2.2",
+    "apollo-server-caching": "^0.2.2",
+    "apollo-server-errors": "^2.2.0",
+    "apollo-server-types": "^0.2.1"
   },
   "devDependencies": {
     "@types/jest": "23.3.3",
@@ -25,6 +34,7 @@
     "jest": "^23.6.0",
     "jest-junit": "^3.6.0",
     "prettier": "^1.12.0",
+    "soap": "^0.25.0",
     "ts-jest": "^23.6.0",
     "tslint": "^5.9.1",
     "tslint-config-prettier": "^1.15.0",
@@ -44,14 +54,5 @@
       "node"
     ],
     "testURL": "http://localhost/"
-  },
-  "peerDependencies": {
-    "soap": "*"
-  },
-  "dependencies": {
-    "apollo-datasource": "^0.2.2",
-    "apollo-server-caching": "^0.2.2",
-    "apollo-server-errors": "^2.2.0",
-    "apollo-server-types": "^0.2.1"
   }
 }

--- a/src/SOAPDataSource.ts
+++ b/src/SOAPDataSource.ts
@@ -1,3 +1,4 @@
+import { get } from '@ovotech/typesafe-get';
 import { DataSource, DataSourceConfig } from 'apollo-datasource';
 import { ApolloError } from 'apollo-server-errors';
 import { ValueOrPromise } from 'apollo-server-types';
@@ -78,7 +79,11 @@ export abstract class SOAPDataSource<TContext = any> extends DataSource {
         return response;
       }
     } catch (error) {
-      throw new ApolloError(error.message, 'SOAP_DATA_SOURCE', { error, method, args });
+      throw new ApolloError(error.message, 'SOAP_DATA_SOURCE', {
+        fault: get(error, 'root', 'Envelope', 'Body', 'Fault'),
+        method,
+        args,
+      });
     }
   }
 }

--- a/src/SOAPDataSource.ts
+++ b/src/SOAPDataSource.ts
@@ -1,4 +1,3 @@
-import { get } from '@ovotech/typesafe-get';
 import { DataSource, DataSourceConfig } from 'apollo-datasource';
 import { ApolloError } from 'apollo-server-errors';
 import { ValueOrPromise } from 'apollo-server-types';
@@ -80,7 +79,7 @@ export abstract class SOAPDataSource<TContext = any> extends DataSource {
       }
     } catch (error) {
       throw new ApolloError(error.message, 'SOAP_DATA_SOURCE', {
-        fault: get(error, 'root', 'Envelope', 'Body', 'Fault'),
+        fault: error && error.root && error.root.Envelope && error.root.Envelope.Body && error.root.Envelope.Body.Fault,
         method,
         args,
       });

--- a/test/SOAPDataSource.spec.ts
+++ b/test/SOAPDataSource.spec.ts
@@ -78,11 +78,28 @@ describe('S3Cache', () => {
   });
 
   it('Should convert error to apollo error', async () => {
-    client.sayHello.mockImplementationOnce((_, cb) => cb(new Error('problem')));
+    const soapError = {
+      message: 'problem',
+      root: {
+        Envelope: {
+          Body: {
+            Fault: {
+              faultcode: 'soap:Server',
+              faultstring: 'Something went wrong',
+            },
+          },
+        },
+      },
+    };
+
+    client.sayHello.mockImplementationOnce((_, cb) => cb(soapError));
 
     await expect(dataSource.greet('tester')).rejects.toEqual(
       new ApolloError('problem', 'SOAP_DATA_SOURCE', {
-        error: new Error('problem'),
+        fault: {
+          faultcode: 'soap:Server',
+          faultstring: 'Something went wrong',
+        },
         method: 'sayHello',
         args: { firstName: 'tester' },
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,11 +18,6 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@ovotech/typesafe-get@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@ovotech/typesafe-get/-/typesafe-get-2.0.1.tgz#736afd5fe1488e4492f44e8e457cfa6e6fca2539"
-  integrity sha512-YDiBIvLlmKyOCprdhlRwN5uYuFAJP+43kDQJBRVBgRckvRcEav+7S2bOx3Ej3O0CKnK5mm65gy83Xvd0pyPPXA==
-
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@ovotech/typesafe-get@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@ovotech/typesafe-get/-/typesafe-get-2.0.1.tgz#736afd5fe1488e4492f44e8e457cfa6e6fca2539"
+  integrity sha512-YDiBIvLlmKyOCprdhlRwN5uYuFAJP+43kDQJBRVBgRckvRcEav+7S2bOx3Ej3O0CKnK5mm65gy83Xvd0pyPPXA==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -3455,7 +3460,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-soap@*:
+soap@*, soap@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/soap/-/soap-0.25.0.tgz#deda92e1454e77ac942033cb7ca18b88f57b0abf"
   integrity sha512-1fCilERdB28ImnjWUFUr0pYxRlZyZNR1zu2uSuHdGRPnC0XKyWbvSm0m8Pll8xIYwecaKIu5Bqcp2zKtEcQcrA==


### PR DESCRIPTION
The SOAP error contains full request and response information as well as fault information.
This has the potential to leak sensitive request information to the user as a GQL error.

Only the fault information is now returned.

Since this removes fields from the GQL error, it's not backwards-compatible and requires a major Semver bump.